### PR TITLE
User friendly error message when Github fails

### DIFF
--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import os
 import json
 import sys
+from urllib.error import URLError
 
 try:
     from urllib.request import urlopen
@@ -76,7 +77,17 @@ class app(Command):
 
     def find_support_pkg(self):
         api_url = 'https://api.github.com/repos/%s/releases' % self.support_project
-        releases = json.loads(urlopen(api_url).read().decode('utf8'))
+
+        try:
+            releases = json.loads(urlopen(api_url).read().decode('utf8'))
+        except URLError:
+            print()
+            print("We had trouble connecting to Github to look for appropriate")
+            print("support packages. This can happen when you have tried too many")
+            print("times. If you are working on briefcase, please use the specified")
+            print("--support-pkg flag for development.")
+            return None
+
         candidates = []
         for release in releases:
             if release['tag_name'].startswith("%s.%s." % (sys.version_info.major, sys.version_info.minor)):


### PR DESCRIPTION
Since we're using the Github API unauthenticated to get releases for support packages, it will time out when being accessed too many times (60) from the same IP Address. When doing development on `briefcase` or especially at an event like a sprint, it can be pretty easy to hit that limit quickly.

This may be more of an edge case however, and not worth complicating the code for it.