### PR TITLE
updated required pip version and added setuptools as an install_requirements entry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,10 @@ setup(
         ]
     },
     install_requires=[
-        'pip >= 7.0',
+        'pip >= 8.1',
         'cookiecutter >= 1.0',
         'voc',
+        'setuptools >= 27.0',
     ],
     license='New BSD',
     classifiers=[


### PR DESCRIPTION
https://github.com/pybee/briefcase/issues/8

pip requirement updated to pip 8.1 and setuptools >= 27.0 added as an install_requires entry, as said in the issue