### PR TITLE
Use the pybee-hosted version of the releases list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'cookiecutter >= 1.0',
         'voc >= 0.1.1',
         'setuptools >= 27.0',
+        'requests < 3.0',
     ],
     license='New BSD',
     classifiers=[


### PR DESCRIPTION
We're moving the release list to pybee.org, this code uses it correctly.

Tested on my machine.