### PR TITLE
Add `--build` and `--execute` options to the setup script

### DIFF
--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -52,6 +52,8 @@ class app(Command):
          'URL for the support package to use'),
         ('download-dir=', None,
          "Directory where the project support packages will be cached"),
+        ('build', None,
+         "Build the project after generating")
     ]
 
     def initialize_options(self):
@@ -70,6 +72,7 @@ class app(Command):
         self.version_code = None
         self.guid = None
         self.secret_key = None
+        self.build = False
 
     def finalize_options(self):
         if self.formal_name is None:
@@ -257,6 +260,9 @@ class app(Command):
     def install_extras(self):
         pass
 
+    def build_app(self):
+        pass
+
     def post_run(self):
         print()
         print("Installation complete.")
@@ -287,5 +293,8 @@ class app(Command):
         self.install_resources()
         self.install_support_package()
         self.install_extras()
+
+        if self.build:
+            self.build_app()
 
         self.post_run()

--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -57,9 +57,9 @@ class app(Command):
         ('execute', None,
          "Run the application after building"),
         ('os-version=', None,
-         "For iOS, the OS version to run (e.g., iOS 10.2)"),
+         "Set the device OS version. Currently only iOS supported (e.g., iOS 10.2)"),
         ('device=', None,
-         "For iOS, the device to run (e.g., iPhone 7 Plus)")
+         "Set the device to run. Currently only iOS supported (e.g., iPhone 7 Plus)")
     ]
 
     def initialize_options(self):
@@ -80,8 +80,8 @@ class app(Command):
         self.secret_key = None
         self.build = False
         self.execute = False
-        self.os_version = 'iOS 10.2'
-        self.device = 'iPhone 7 Plus'
+        self.os_version = None
+        self.device = None
 
     def finalize_options(self):
         if self.formal_name is None:

--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -53,7 +53,13 @@ class app(Command):
         ('download-dir=', None,
          "Directory where the project support packages will be cached"),
         ('build', None,
-         "Build the project after generating")
+         "Build the project after generating"),
+        ('execute', None,
+         "Run the application after building"),
+        ('os-version', None,
+         "For iOS, the OS version to run (e.g., iOS 10.2)"),
+        ('device', None,
+         "For iOS, the device to run (e.g., iPhone 7 Plus)")
     ]
 
     def initialize_options(self):
@@ -73,6 +79,9 @@ class app(Command):
         self.guid = None
         self.secret_key = None
         self.build = False
+        self.execute = False
+        self.os_version = 'iOS 10.2'
+        self.device = 'iPhone 7 Plus'
 
     def finalize_options(self):
         if self.formal_name is None:
@@ -114,6 +123,9 @@ class app(Command):
             self.secret_key = ''.join(random.choice("abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)") for i in range(40))
 
         pip.utils.ensure_dir(self.download_dir)
+
+        if self.execute:
+            self.build = True
 
     def find_support_pkg(self):
         api_url = 'https://api.github.com/repos/%s/releases' % self.support_project
@@ -263,6 +275,9 @@ class app(Command):
     def build_app(self):
         pass
 
+    def run_app(self):
+        pass
+
     def post_run(self):
         print()
         print("Installation complete.")
@@ -296,5 +311,7 @@ class app(Command):
 
         if self.build:
             self.build_app()
+        if self.execute:
+            self.run_app()
 
         self.post_run()

--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -56,9 +56,9 @@ class app(Command):
          "Build the project after generating"),
         ('execute', None,
          "Run the application after building"),
-        ('os-version', None,
+        ('os-version=', None,
          "For iOS, the OS version to run (e.g., iOS 10.2)"),
-        ('device', None,
+        ('device=', None,
          "For iOS, the device to run (e.g., iPhone 7 Plus)")
     ]
 

--- a/briefcase/ios.py
+++ b/briefcase/ios.py
@@ -26,6 +26,12 @@ class ios(app):
 
         self.resource_dir = self.dir
 
+        if self.os_version is None:
+            self.os_version = 'iOS 10.2'
+
+        if self.device is None:
+            self.device = 'iPhone 7 Plus'
+
     def install_icon(self):
         last_size = None
         for size in ['180', '167', '152', '120', '87', '80', '76', '58', '40', '29']:

--- a/briefcase/ios.py
+++ b/briefcase/ios.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 
+import subprocess
+
 from .app import app
 
 
@@ -55,3 +57,20 @@ class ios(app):
                 )
             else:
                 print("WARNING: No %s splash file available." % size)
+
+    def build_app(self):
+        project_file = '%s.xcodeproj' % self.formal_name
+        build_settings = [
+            ('CODE_SIGNING_REQUIRED', 'NO'),
+            ('CODE_SIGN_IDENTITY', ''),
+            ('CODE_SIGN_ENTITLEMENTS', ''),
+            ('CODE_SIGNING_ALLOWED', 'NO')
+        ]
+        build_settings_str = ['%s="%s"' % x for x in build_settings]
+
+        print(' * Building XCode project...')
+
+        subprocess.Popen([
+            'xcodebuild', '-project', project_file, *build_settings_str, '-destination',
+            'platform="iOS Simulator",name="iPhone 7",OS="latest"', '-quiet', 'build'
+        ], cwd=os.path.abspath(self.dir)).wait()

--- a/briefcase/ios.py
+++ b/briefcase/ios.py
@@ -96,16 +96,14 @@ class ios(app):
 
         device = device_list[0]
 
-        # Boot device, install app, and launch
+        # Install app and launch simulator
         print(' * Launching app...')
-
-        if device['state'] == 'Shutdown':
-            subprocess.Popen(['xcrun', 'simctl', 'boot', device['udid']])
 
         app_identifier = '.'.join([self.bundle, self.formal_name.replace(' ', '-')])
 
-        subprocess.Popen(['xcrun', 'simctl', 'uninstall', device['udid'], app_identifier], cwd=working_dir).wait()
+        subprocess.Popen(['xcrun', 'instruments', '-w', device['udid']]).wait()
 
+        subprocess.Popen(['xcrun', 'simctl', 'uninstall', device['udid'], app_identifier], cwd=working_dir).wait()
         subprocess.Popen([
             'xcrun', 'simctl', 'install', device['udid'],
             os.path.join('build', 'Debug-iphonesimulator', '%s.app' % self.formal_name)
@@ -113,4 +111,4 @@ class ios(app):
 
         subprocess.Popen([
             'xcrun', 'simctl', 'launch', device['udid'], app_identifier
-        ])
+        ]).wait()


### PR DESCRIPTION
This PR adds a `--build` option, which will automatically build the Xcode project, and an `--execute` option, which will launch the app in the iOS simulator. Additional `--os` and `--device` options allow the user to build/run the app on different OS/device combinations.

Currently, these options are ignored for all targets other than iOS. ~~I plan to add an implementation for macOS next.~~ (I see this isn't necessary for macOS)