### PR TITLE
Make sure `finalize_options()` is called with command line args applied

### DIFF
--- a/briefcase/ios.py
+++ b/briefcase/ios.py
@@ -17,6 +17,8 @@ class ios(app):
             if getattr(self, attr) is None:
                 setattr(self, attr, getattr(finalized, attr))
 
+        super(ios, self).finalize_options()
+
         # Set platform-specific options
         self.platform = 'iOS'
         self.support_project = "pybee/Python-Apple-Support"


### PR DESCRIPTION
`app.finalize_options()` is called during `ios.finalize_options` through a call to `self.get_finalized_command('app')`. This ensures that the options in `setup.py` are incorporated, but during the call to `app.finalize_options()`, the command line arguments have not yet been processed, so when `--execute` is passed in via the command line, `build` is not properly set in these two lines in `app.finalize_options()`:

```python
if self.execute:
    self.build = True
```

This PR resolves the issue by calling super in `ios.finalize_options()` after the `setup.py` options are integrated.