### PR TITLE
Windows: use numeric version numbers.

### DIFF
--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -57,7 +57,9 @@ class app(Command):
         ('os-version=', None,
          "Set the device OS version. (e.g., iOS 10.2)"),
         ('device-name=', None,
-         "Set the device to run. (e.g., iPhone 7 Plus)")
+         "Set the device to run. (e.g., iPhone 7 Plus)"),
+        ('sanitize-version', None,
+         "Forces installer version to only contain numbers.")
     ]
 
     def initialize_options(self):
@@ -80,6 +82,7 @@ class app(Command):
         self.start = False
         self.os_version = None
         self.device_name = None
+        self.sanitize_version = None
 
     def finalize_options(self):
         if self.formal_name is None:
@@ -167,6 +170,13 @@ class app(Command):
 
     def generate_app_template(self, extra_context=None):
         print(" * Writing application template...")
+
+        if self.sanitize_version and self.version_numeric != self.version:
+            print(" ! Version currently contains characters: %s" % self.version)
+            print(" ! Installer version sanitized to: %s" % self.version_numeric)
+
+            extra_context = extra_context or {}
+            extra_context['version'] = self.version_numeric
 
         if self.template is None:
             template_path = os.path.expanduser('~/.cookiecutters/Python-%s-template' % self.platform)

--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -111,10 +111,7 @@ class app(Command):
             int(match.groups()[4]) if match.groups()[4] else 0,
         )
         self.version_code = '%02d%02d%02d' % self._numeric_version_parts
-        self.numeric_version = '%d.%d.%d' % self._numeric_version_parts
-        if self.version != self.distribution.get_version():
-            print("Installer needs version in format x.x.x where x is integer")
-            print("Using version: %s" % self.version)
+        self.version_numeric = '%d.%d.%d' % self._numeric_version_parts
 
         # The app's GUID (if not manually specified) is a namespace UUID
         # based on the URL for the app.
@@ -168,7 +165,7 @@ class app(Command):
     def version(self):
         return self.distribution.get_version()
 
-    def generate_app_template(self):
+    def generate_app_template(self, extra_context=None):
         print(" * Writing application template...")
 
         if self.template is None:
@@ -179,26 +176,29 @@ class app(Command):
             else:
                 self.template = 'https://github.com/pybee/Python-%s-template.git' % self.platform
         print("Project template: %s" % self.template)
+        _extra_context = {
+            'app_name': self.distribution.get_name(),
+            'formal_name': self.formal_name,
+            'class_name': self.class_name,
+            'organization_name': self.organization_name,
+            'author': self.distribution.get_author(),
+            'description': self.distribution.get_description(),
+            'dir_name': self.dir,
+            'bundle': self.bundle,
+            'year': date.today().strftime('%Y'),
+            'month': date.today().strftime('%B'),
+            'version': self.version,
+            'version_code': self.version_code,
+            'guid': self.guid,
+            'secret_key': self.secret_key,
+        }
+        if extra_context:
+            _extra_context.update(extra_context)
         cookiecutter(
             self.template,
             no_input=True,
             checkout='%s.%s' % (sys.version_info.major, sys.version_info.minor),
-            extra_context={
-                'app_name': self.distribution.get_name(),
-                'formal_name': self.formal_name,
-                'class_name': self.class_name,
-                'organization_name': self.organization_name,
-                'author': self.distribution.get_author(),
-                'description': self.distribution.get_description(),
-                'dir_name': self.dir,
-                'bundle': self.bundle,
-                'year': date.today().strftime('%Y'),
-                'month': date.today().strftime('%B'),
-                'version': self.version,
-                'version_code': self.version_code,
-                'guid': self.guid,
-                'secret_key': self.secret_key,
-            }
+            extra_context=_extra_context
         )
 
     def git_pull(self, path):

--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -105,11 +105,16 @@ class app(Command):
         # The Version Code is a pure-string, numerically sortable
         # version number.
         match = re.match('(?P<major>\d+)(\.(?P<minor>\d+)(\.(?P<revision>\d+))?)?', self.distribution.get_version())
-        self.version_code = '%02d%02d%02d' % (
+        self._version_tuple = (
             int(match.groups()[0]) if match.groups()[0] else 0,
             int(match.groups()[2]) if match.groups()[2] else 0,
             int(match.groups()[4]) if match.groups()[4] else 0,
         )
+        self.version_code = '%02d%02d%02d' % self._version_tuple
+        self.version = '%d.%d.%d' % self._version_tuple
+        if self.version != self.distribution.get_version():
+            print("Installer needs version in format x.x.x where x is integer")
+            print("Using version: %s" % self.version)
 
         # The app's GUID (if not manually specified) is a namespace UUID
         # based on the URL for the app.
@@ -158,10 +163,6 @@ class app(Command):
     @property
     def app_packages_dir(self):
         return os.path.join(os.getcwd(), self.resource_dir, 'app_packages')
-
-    @property
-    def version(self):
-        return self.distribution.get_version()
 
     def generate_app_template(self):
         print(" * Writing application template...")

--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -105,13 +105,13 @@ class app(Command):
         # The Version Code is a pure-string, numerically sortable
         # version number.
         match = re.match('(?P<major>\d+)(\.(?P<minor>\d+)(\.(?P<revision>\d+))?)?', self.distribution.get_version())
-        self._version_tuple = (
+        self._numeric_version_parts = (
             int(match.groups()[0]) if match.groups()[0] else 0,
             int(match.groups()[2]) if match.groups()[2] else 0,
             int(match.groups()[4]) if match.groups()[4] else 0,
         )
-        self.version_code = '%02d%02d%02d' % self._version_tuple
-        self.version = '%d.%d.%d' % self._version_tuple
+        self.version_code = '%02d%02d%02d' % self._numeric_version_parts
+        self.numeric_version = '%d.%d.%d' % self._numeric_version_parts
         if self.version != self.distribution.get_version():
             print("Installer needs version in format x.x.x where x is integer")
             print("Using version: %s" % self.version)
@@ -163,6 +163,10 @@ class app(Command):
     @property
     def app_packages_dir(self):
         return os.path.join(os.getcwd(), self.resource_dir, 'app_packages')
+
+    @property
+    def version(self):
+        return self.distribution.get_version()
 
     def generate_app_template(self):
         print(" * Writing application template...")

--- a/briefcase/windows.py
+++ b/briefcase/windows.py
@@ -35,13 +35,10 @@ class windows(app):
         self.icon_filename = os.path.join(self.app_dir, self.distribution.get_name() + os.path.splitext(iconfile)[1])
 
     def generate_app_template(self, extra_context=None):
-
-        if self.version_numeric != self.version:
-            print(" ! Windows Installer version can only contain numerals.")
-            print(" ! Using version: %s" % self.version_numeric)
-
-            extra_context = extra_context or {}
-            extra_context['version'] = self.version_numeric
+        if self.version_numeric != self.version and not self.sanitize_version:
+            print(" ! Windows Installer version can only contain numerals, currently: %s" % self.version)
+            print(" ! --sanitize-version can be used to automatically filter this to %s" % self.version_numeric)
+            exit(1)
 
         super(windows, self).generate_app_template(extra_context=extra_context)
 

--- a/briefcase/windows.py
+++ b/briefcase/windows.py
@@ -34,6 +34,17 @@ class windows(app):
         iconfile = '%s.ico' % self.icon
         self.icon_filename = os.path.join(self.app_dir, self.distribution.get_name() + os.path.splitext(iconfile)[1])
 
+    def generate_app_template(self, extra_context=None):
+
+        if self.version_numeric != self.version:
+            print(" ! Windows Installer version can only contain numerals.")
+            print(" ! Using version: %s" % self.version_numeric)
+
+            extra_context = extra_context or {}
+            extra_context['version'] = self.version_numeric
+
+        super(windows, self).generate_app_template(extra_context=extra_context)
+
     def install_icon(self):
         shutil.copyfile('%s.ico' % self.icon, self.icon_filename)
 


### PR DESCRIPTION
Windows installer fails when non-integer elements are present in the version string.

I ran into this trying to use briefcase with a package using setuptools_scm which gave me a version number like "1.2.dev7+g3126144.d20170908".

This isn't a particularly elegant solution, but it's a suggestion of how I've worked around the issue.