### PR TITLE
Detect failures in build_app()

### DIFF
--- a/briefcase/android.py
+++ b/briefcase/android.py
@@ -107,11 +107,13 @@ class android(app):
     def build_app(self):
         if not self.start:
             print(" * Building %s..." % (self.formal_name))
-            subprocess.Popen([
+            proc = subprocess.Popen([
                     './gradlew', 'build'
                 ],
                 cwd=os.path.abspath(self.dir)
-            ).wait()
+            )
+            proc.wait()
+            return proc.returncode == 0
 
     def post_build(self):
         if not self.start:

--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -343,8 +343,9 @@ class app(Command):
         self.install_extras()
         self.post_install()
         if self.build:
-            self.build_app()
-            self.post_build()
+            success = self.build_app()
+            if success is None or success is True:
+                self.post_build()
         if self.start:
             self.start_app()
             self.post_start()

--- a/briefcase/django.py
+++ b/briefcase/django.py
@@ -112,17 +112,22 @@ class django(app):
 
     def build_app(self):
         print(" * Building Webpack assets...")
-        subprocess.Popen(
+        proc = subprocess.Popen(
             [shutil.which("npm"), "run", "build"],
             cwd=os.path.abspath(self.dir)
-        ).wait()
+        )
+        proc.wait()
+        if proc.returncode != 0:
+            return False
 
         print(' * Applying migrations...')
-        subprocess.Popen([
+        proc = subprocess.Popen([
                 sys.executable, './manage.py', 'migrate'
             ],
             cwd=os.path.abspath(self.dir)
-        ).wait()
+        )
+        proc.wait()
+        return proc.returncode == 0
 
     def start_app(self):
         print(" * Starting Django server on %s" % self.device_name)

--- a/briefcase/ios.py
+++ b/briefcase/ios.py
@@ -137,7 +137,7 @@ class ios(app):
 
     def build_app(self):
         if not self.has_required_xcode_version():
-            return
+            return False
 
         project_file = '%s.xcodeproj' % self.formal_name
         build_settings = [
@@ -153,11 +153,13 @@ class ios(app):
 
         print(' * Building XCode project for %s %s...' % (self.device_name, self.os_version))
 
-        subprocess.Popen([
+        proc = subprocess.Popen([
             'xcodebuild', ' '.join(build_settings_str), '-project', project_file, '-destination',
             'platform="iOS Simulator,name=%s,OS=%s"' % (self.device_name, self.os_version), '-quiet', '-configuration',
             'Debug', '-arch', 'x86_64', '-sdk', 'iphonesimulator%s' % (self.os_version.split(' ')[-1],), 'build'
-        ], cwd=os.path.abspath(self.dir)).wait()
+        ], cwd=os.path.abspath(self.dir))
+        proc.wait()
+        return proc.returncode == 0
 
     def start_app(self):
         if not self.has_required_xcode_version():

--- a/briefcase/linux.py
+++ b/briefcase/linux.py
@@ -39,7 +39,7 @@ class linux(app):
         pass
 
     def build_app(self):
-        pass
+        return True
 
     def post_build(self):
         pass

--- a/briefcase/macos.py
+++ b/briefcase/macos.py
@@ -36,7 +36,7 @@ class macos(app):
         raise RuntimeError("macOS doesn't support splash screens.")
 
     def build_app(self):
-        pass
+        return True
 
     def post_build(self):
         pass

--- a/briefcase/windows.py
+++ b/briefcase/windows.py
@@ -123,16 +123,19 @@ class windows(app):
             print("   - Using %s" % wix_path)
 
         print(" * Compiling application installer...")
-        subprocess.Popen(
+        proc = subprocess.Popen(
             [
                 os.path.join(wix_path, 'bin', 'candle'),
                 "briefcase.wxs"
             ],
             cwd=os.path.abspath(self.dir)
-        ).wait()
+        )
+        proc.wait()
+        if proc.returncode != 0:
+            return False
 
         print(" * Linking application installer...")
-        subprocess.Popen(
+        proc = subprocess.Popen(
             [
                 os.path.join(wix_path, 'bin', 'light'),
                 "-ext", "WixUIExtension",
@@ -140,7 +143,9 @@ class windows(app):
                 "briefcase.wixobj"
             ],
             cwd=os.path.abspath(self.dir)
-        ).wait()
+        )
+        proc.wait()
+        return proc.returncode == 0
 
     def start_app(self):
         print()


### PR DESCRIPTION
Currently, if anything fails in the various build_app() subprocesses it goes undetected, leaving briefcase trying to continue regardless. It eventually reports "Build complete." regardless of whether it has succeeded or not.
This PR monitors the returncode from the subprocess calls and reports failures if detected.

Now, post_build() will only be run on success of build_app()