### PR TITLE
Add cmdline option to answer delete existing folder question

### DIFF
--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -60,8 +60,8 @@ class app(Command):
          "Set the device to run. (e.g., iPhone 7 Plus)"),
         ('sanitize-version', None,
          "Forces installer version to only contain numbers."),
-        ('delete-existing=', None,
-         "Set whether to delete existing staging folder")
+        ('clean', None,
+         "Delete any artifacts from previous run")
     ]
 
     def initialize_options(self):
@@ -85,7 +85,7 @@ class app(Command):
         self.os_version = None
         self.device_name = None
         self.sanitize_version = None
-        self.delete_existing = None
+        self.clean = None
 
     def finalize_options(self):
         if self.formal_name is None:
@@ -336,16 +336,7 @@ class app(Command):
         full_generation = True
         if os.path.exists(self.dir):
             print()
-            if self.delete_existing:
-                confirm = self.delete_existing
-            else:
-                if os.path.isdir(self.dir):
-                    confirm = input("A directory named '%s' already exists. Would you like to replace it (y/N)? " % self.dir)
-                else:
-                    confirm = input("A file named '%s' already exists. Would you like to delete it (y/N)? " % self.dir)
-                print()
-
-            if confirm in ['y', 'Y']:
+            if self.clean:
                 print(" * Deleting existing content...")
                 if os.path.isdir(self.dir):
                     shutil.rmtree(self.dir)

--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -59,7 +59,9 @@ class app(Command):
         ('device-name=', None,
          "Set the device to run. (e.g., iPhone 7 Plus)"),
         ('sanitize-version', None,
-         "Forces installer version to only contain numbers.")
+         "Forces installer version to only contain numbers."),
+        ('delete-existing=', None,
+         "Set whether to delete existing staging folder")
     ]
 
     def initialize_options(self):
@@ -83,6 +85,7 @@ class app(Command):
         self.os_version = None
         self.device_name = None
         self.sanitize_version = None
+        self.delete_existing = None
 
     def finalize_options(self):
         if self.formal_name is None:
@@ -333,12 +336,15 @@ class app(Command):
         full_generation = True
         if os.path.exists(self.dir):
             print()
-            if os.path.isdir(self.dir):
-                confirm = input("A directory named '%s' already exists. Would you like to replace it (y/N)? " % self.dir)
+            if self.delete_existing:
+                confirm = self.delete_existing
             else:
-                confirm = input("A file named '%s' already exists. Would you like to delete it (y/N)? " % self.dir)
+                if os.path.isdir(self.dir):
+                    confirm = input("A directory named '%s' already exists. Would you like to replace it (y/N)? " % self.dir)
+                else:
+                    confirm = input("A file named '%s' already exists. Would you like to delete it (y/N)? " % self.dir)
+                print()
 
-            print()
             if confirm in ['y', 'Y']:
                 print(" * Deleting existing content...")
                 if os.path.isdir(self.dir):


### PR DESCRIPTION
If --delete-existing=[y,n] is provided on the command line, this answer will be used rather than asking the user to manually reply when a staging folder already exists.