### PR TITLE
Allow use of Setuptools launchers

### DIFF
--- a/briefcase/app.py
+++ b/briefcase/app.py
@@ -269,9 +269,10 @@ class app(Command):
     @property
     def launcher_header(self):
         """
-        Override the shebang line for launcher scripts
+        Optionally override the shebang line for launcher scripts
         This should return a suitable relative path which will find the
-        bundled python for the relevant platform
+        bundled python for the relevant platform if the setuptools default
+        is not suitable.
         """
         return None
 

--- a/briefcase/linux.py
+++ b/briefcase/linux.py
@@ -38,6 +38,19 @@ class linux(app):
         # No support package; we just use the system python
         pass
 
+    @property
+    def launcher_header(self):
+        """
+        Override the shebang line for launcher scripts
+        This should return a suitable relative path which will find the
+        bundled python for the relevant platform
+        """
+        return "#!python%s.%s\n" % (sys.version_info.major, sys.version_info.minor)
+
+    @property
+    def launcher_script_location(self):
+        return self.resource_dir
+
     def build_app(self):
         return True
 

--- a/briefcase/linux.py
+++ b/briefcase/linux.py
@@ -42,8 +42,6 @@ class linux(app):
     def launcher_header(self):
         """
         Override the shebang line for launcher scripts
-        This should return a suitable relative path which will find the
-        bundled python for the relevant platform
         """
         return "#!python%s.%s\n" % (sys.version_info.major, sys.version_info.minor)
 

--- a/briefcase/macos.py
+++ b/briefcase/macos.py
@@ -51,15 +51,6 @@ class macos(app):
         macos_dir = os.path.abspath(os.path.join(self.resource_dir, '..', 'MacOS'))
         return macos_dir
 
-    # def install_launch_scripts(self):
-    #     exes = super(macos, self).install_launch_scripts()
-        # if self.formal_name in exes:
-        #     # If a main launcher has been created, remove template app and symlink to launcher
-        #     main_app = os.path.join(self.resource_dir, '..', 'MacOS', self.formal_name)
-        #     if os.path.exists(main_app):
-        #         os.unlink(main_app)
-        #         os.symlink(os.path.join('..', 'Resources', self.formal_name), main_app)
-
     def build_app(self):
         return True
 

--- a/briefcase/macos.py
+++ b/briefcase/macos.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import shutil
 import subprocess
 
@@ -34,6 +35,30 @@ class macos(app):
 
     def install_splash(self):
         raise RuntimeError("macOS doesn't support splash screens.")
+
+    @property
+    def launcher_header(self):
+        """
+        Override the shebang line for launcher scripts
+        """
+        # https://stackoverflow.com/a/36160331
+        pyexe = '../Resources/python/bin/python%s' % (3 if sys.version_info.major == 3 else '')
+        return '#!/bin/sh\n'\
+               '"exec" "`dirname $0`/%s" "$0" "$@"\n' % pyexe
+
+    @property
+    def launcher_script_location(self):
+        macos_dir = os.path.abspath(os.path.join(self.resource_dir, '..', 'MacOS'))
+        return macos_dir
+
+    # def install_launch_scripts(self):
+    #     exes = super(macos, self).install_launch_scripts()
+        # if self.formal_name in exes:
+        #     # If a main launcher has been created, remove template app and symlink to launcher
+        #     main_app = os.path.join(self.resource_dir, '..', 'MacOS', self.formal_name)
+        #     if os.path.exists(main_app):
+        #         os.unlink(main_app)
+        #         os.symlink(os.path.join('..', 'Resources', self.formal_name), main_app)
 
     def build_app(self):
         return True

--- a/briefcase/windows.py
+++ b/briefcase/windows.py
@@ -62,7 +62,6 @@ class windows(app):
         """
         return "#!.\python\python.exe\n"
 
-
     def install_extras(self):
         print(" * Finalizing application installer script...")
 

--- a/briefcase/windows.py
+++ b/briefcase/windows.py
@@ -117,7 +117,6 @@ class windows(app):
             for entries in self.distribution.entry_points.values():
                 for entry in entries:
                     exe_name = entry.split('=')[0].strip()
-                    appdir = self.app_dir
                     description = self.distribution.get_description()
                     shortcutid = uuid.uuid4().hex
                     shortcuts.append("""\
@@ -126,8 +125,8 @@ class windows(app):
                                 Name="{exe_name}"
                                 Icon="ProductIcon"
                                 Description="{description}"
-                                Target="{appdir}\\{exe_name}.exe"
-                                WorkingDirectory="{appdir}" />""".format(**locals()))
+                                Target="[AppDir]\\app\\{exe_name}.exe"
+                                WorkingDirectory="AppDir" />""".format(**locals()))
 
         # Generate the full briefcase.wxs file
         lines = []
@@ -137,7 +136,7 @@ class windows(app):
                     lines.extend(content)
                 elif line.strip() == '<!-- CONTENTREFS -->':
                     lines.extend(contentrefs)
-                elif line.strip() == '< !-- SHORTCUTS_PROVIDED -->':
+                elif line.strip() == '<!-- SHORTCUTS_PROVIDED -->':
                     # Comment out existing shortcut in template
                     lines.append('                        <!--')
                 elif line.strip() == '<!-- SHORTCUTS -->':

--- a/briefcase/windows.py
+++ b/briefcase/windows.py
@@ -52,6 +52,16 @@ class windows(app):
         version = "%s.%s.%s" % sys.version_info[:3]
         return 'https://www.python.org/ftp/python/%s/python-%s-embed-amd64.zip' % (version, version)
 
+    @property
+    def launcher_header(self):
+        """
+        Override the shebang line for launcher scripts
+        This should return a suitable relative path which will find the
+        bundled python for the relevant platform
+        """
+        return "#!.\python\python.exe\n"
+
+
     def install_extras(self):
         print(" * Finalizing application installer script...")
 

--- a/docs/background/quickstart.rst
+++ b/docs/background/quickstart.rst
@@ -76,7 +76,7 @@ You can also use the ``-b`` (or ``--build``) argument to automatically
 perform any compilation step required; or use ``-s`` (``--start``) to
 start the application.
 
-For desktop os's (macOS, Windows, Linux) the entry point(s) to your program can
+For desktop OS's (macOS, Windows, Linux) the entry point(s) to your program can
 be defined in ``setup.py`` as console and gui scripts::
 
     setup(
@@ -94,8 +94,8 @@ be defined in ``setup.py`` as console and gui scripts::
 For more details on the format see:
 http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
 
-On windows and linux this allows for multiple executables to be defined.
-MacOS will use the entry point with the same name as your `formal_name` as the
+On Windows and Linux this allows for multiple executables to be defined.
+macOS will use the entry point with the same name as your `formal_name` as the
 main application, any others will be available in the Contents/MacOS folder inside the
 application bundle.
 

--- a/docs/background/quickstart.rst
+++ b/docs/background/quickstart.rst
@@ -75,3 +75,29 @@ Then, you can invoke ``briefcase``, using:
 You can also use the ``-b`` (or ``--build``) argument to automatically
 perform any compilation step required; or use ``-s`` (``--start``) to
 start the application.
+
+For desktop os's (macOS, Windows, Linux) the entry point(s) to your program can
+be defined in ``setup.py`` as console and gui scripts::
+
+    setup(
+        ...
+        entry_points={
+            'gui_scripts': [
+                'Example = example.gui:main [GUI]',
+            ],
+            'console_scripts': [
+                'utility = example.main:main',
+            ]
+        }
+        ...
+
+For more details on the format see:
+http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
+
+On windows and linux this allows for multiple executables to be defined.
+MacOS will use the entry point with the same name as your `formal_name` as the
+main application, any others will be available in the Contents/MacOS folder inside the
+application bundle.
+
+For other platforms the entry point is defined in the platform template, typically
+they require the __main__.py module to be defined explicitly in code.


### PR DESCRIPTION
Currently the application startup script is hard coded in the per-platform template.  
This is quite restrictive in that it only works if you have a module named 'app' with a function 'main' which returns an object with a function `main_loop` (on windows at least, other platforms can be different).

Also, on windows this means that in task manager you see `pythonw.exe` rather than the name of the distributed application.

To make briefcase more flexible I propose using the built in mechanism for defining entry points / applications. 
On windows this already creates exe launchers that have the desired application names. 
This also allows having multiple gui and console applications in the one installer package.

In this PR the windows launcher creation has been modified slightly to create relocatable exe applications in the contents/app folder.
Start menu shortcuts will be created for each of these rather than the static launcher currently defined in the template.
These executables will show  in task manager with the user specified names.

On linux, executable launch scripts will be created for each entrypoint defined.

On MacOS, if an entrypoint is defined with the same name as the `formal_name` specified it will be the main application. There are launch scripts for any others also defined in the bundle/Contents/MacOS the an end user could run from the command line etc. 

Mobile platforms have not been adapted to this mechanism as there's no way to produce multiple executables. 
If desired however they could also be updated in the same way to allow defining the custom entry point which would be used in preference to the templated method.

If no entry_points are defined it falls back to the launching mechanism as defined in the platform templates.