### PR TITLE
Windows: Limit directory id length in wix project

### DIFF
--- a/briefcase/windows.py
+++ b/briefcase/windows.py
@@ -70,6 +70,7 @@ class windows(app):
         content = []
         contentrefs = []
         shortcuts = []
+        dir_ids = []
 
         def walk_dir(path, depth=0):
             files = []
@@ -81,9 +82,15 @@ class windows(app):
                     full_parts = parts + [name]
                 else:
                     full_parts = [name]
-                dir_id = '.'.join(re.sub('[^A-Za-z0-9_]', '_', p) for p in full_parts)
 
                 if os.path.isdir(full_path):
+                    dir_id = '.'.join(re.sub('[^A-Za-z0-9_]', '_', p) for p in full_parts)
+                    if len(dir_id) > 68:
+                        dir_id = '...' + dir_id[-65:]
+                    while dir_id in dir_ids:
+                        dir_id = '...' + dir_id[4:]
+                    dir_ids.append(dir_id)
+
                     content.append(
                         '    ' * (depth + 5) + '<Directory Id="DIR_%s" Name="%s">' % (
                             dir_id, name


### PR DESCRIPTION
On Windows, WIX has a max directory id length of 72

As the id is generated from path names this can easily exceed this, at which point a warning is shown during build:
```
C:\build\PC-App-2\windows\briefcase.wxs(10552) : warning CNDL1026 : The Directory/@Id attribute's 
value, 'DIR_app_packages.pip._vendor.requests.packages.urllib3.contrib.__pycache__', 
is too long for an identifier.  Standard identifiers are 72 characters long or less.
```

This limits the id (generated from file path) to this restriction