### PR TITLE
Windows: Regenerate the file list in the wix project on every build.

### DIFF
--- a/briefcase/windows.py
+++ b/briefcase/windows.py
@@ -102,8 +102,20 @@ class windows(app):
         walk_dir(app_root)
 
         # Generate the full briefcase.wxs file
+        briefcase_wxs = os.path.join(self.dir, 'briefcase.wxs')
+        briefcase_wxs_orig = briefcase_wxs + '.orig'
+
+        if os.path.exists(briefcase_wxs_orig):
+            try:
+                os.unlink(briefcase_wxs)
+            except OSError:
+                pass
+            shutil.copyfile(briefcase_wxs_orig, briefcase_wxs)
+        else:
+            shutil.copyfile(briefcase_wxs, briefcase_wxs_orig)
+
         lines = []
-        with open(os.path.join(self.dir, 'briefcase.wxs')) as template:
+        with open(briefcase_wxs) as template:
             for line in template:
                 if line.strip() == '<!-- CONTENT -->':
                     lines.extend(content)
@@ -112,7 +124,7 @@ class windows(app):
                 else:
                     lines.append(line.rstrip())
 
-        with open(os.path.join(self.dir, 'briefcase.wxs'), 'w') as template:
+        with open(briefcase_wxs, 'w') as template:
             for line in lines:
                 template.write('%s\n' % line)
 


### PR DESCRIPTION
On windows, the wix project template is currently only generated on a clean build.
Subsequent builds without the `--clean` argument update files included in the staging folder, but the wix project doesn't get updated again as the template tags have already been replaced.

This ensures the file list can be regenerated in the wix project every build.

On the first build, before filling the file lists into the wix template the file is backed up.
This occurs after the cookiecutter filling out of project name, description, etc.

On subsequent builds the template is restored from the backup before re-filling the file lists.