### PR TITLE
Fix the broken link for "quick start" in Readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _BeeWare suite: http://pybee.org
 .. _Read The Docs: https://briefcase.readthedocs.io
-.. _Quickstart: https://briefcase.readthedocs.io/en/latest/intro/quickstart.html
+.. _Quickstart: https://briefcase.readthedocs.io/en/latest/background/quickstart.html
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _pybee/general: https://gitter.im/pybee/general
 .. _BeeWare Community Code of Conduct: http://pybee.org/community/behavior/


### PR DESCRIPTION
Current hyperlink for "quick start" displays the following error, so I replaced it with the correct one.


        \          SORRY            /
         \                         /
          \    This page does     /
           ]   not exist yet.    [    ,'|
           ]                     [   /  |
           ]___               ___[ ,'   |
           ]  ]\             /[  [ |:   |
           ]  ] \           / [  [ |:   |
           ]  ]  ]         [  [  [ |:   |
           ]  ]  ]__     __[  [  [ |:   |
           ]  ]  ] ]\ _ /[ [  [  [ |:   |
           ]  ]  ] ] (#) [ [  [  [ :===='
           ]  ]  ]_].nHn.[_[  [  [
           ]  ]  ]  HHHHH. [  [  [
           ]  ] /   `HH("N  \ [  [
           ]__]/     HHH  "  \[__[
           ]         NNN         [
           ]         N/"         [
           ]         N H         [
          /          N            \
         /           q,            \
        /                           \