### PR TITLE
Add more information to the setup.py for briefcase

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,11 @@ setup(
         'Topic :: Software Development',
         'Topic :: Utilities',
     ],
-    test_suite='tests'
+    test_suite='tests',
+    package_urls={
+        'Funding': 'https://pybee.org/contributing/membership/',
+        'Documentation': 'http://briefcase.readthedocs.io/en/latest/',
+        'Tracker': 'https://github.com/pybee/briefcase/issues',
+        'Source': 'https://github.com/pybee/briefcase',
+    },
 )


### PR DESCRIPTION
Per https://packaging.python.org/tutorials/distributing-packages/#project-urls
we can have even more helpful information in our package and on our PyPI page by
adding urls to the setup.py