### PR TITLE
Fix: "IndexError: tuple index out of range"

### DIFF
--- a/briefcase/django.py
+++ b/briefcase/django.py
@@ -52,11 +52,11 @@ class django(app):
         if len(parts) == 0:
             return '1.0.0'
         elif len(parts) == 1:
-            return '{}.0.0'.format(tuple(parts))
+            return '{}.0.0'.format(*parts)
         elif len(parts) == 2:
-            return '{}.{}.0'.format(tuple(parts))
+            return '{}.{}.0'.format(*parts)
         else:
-            return '{}.{}.{}'.format(tuple(parts[:3]))
+            return '{}.{}.{}'.format(*parts[:3])
 
     def install_icon(self):
         raise RuntimeError("Django doesn't support icons.")


### PR DESCRIPTION
```
$ python setup.py django -s
running django
 * Writing application template...
Project template: https://github.com/pybee/Python-Django-template.git
Traceback (most recent call last):
  File "setup.py", line 103, in <module>
    'toga-django',
  File "/home/jens/repos/RunCalculator-Env/lib/python3.5/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/home/jens/repos/RunCalculator-Env/src/briefcase/briefcase/app.py", line 452, in run
    self.generate_app_template()
  File "/home/jens/repos/RunCalculator-Env/src/briefcase/briefcase/app.py", line 215, in generate_app_template
    'version': self.version,
  File "/home/jens/repos/RunCalculator-Env/src/briefcase/briefcase/django.py", line 59, in version
    return '{}.{}.{}'.format(tuple(parts[:3]))
IndexError: tuple index out of range
```
The result of **tuple(parts[:3])** is: **('0', '0', '1')**
So i didn't see the problem here...

I just patch **'{}.{}.{}'.format(tuple(parts[:3]))** to **'.'.join(parts[:3])**