### PR TITLE
Fix tuple index error on ios app creation

### DIFF
--- a/briefcase/ios.py
+++ b/briefcase/ios.py
@@ -147,7 +147,7 @@ class ios(app):
             ('ARCHS', 'x86_64'),
             ('ONLY_ACTIVE_ARCHS', 'NO')
         ]
-        build_settings_str = ['{}={}'.format(x for x in build_settings)]
+        build_settings_str = ['{0[0]}={0[1]}'.format(x) for x in build_settings]
 
         self.set_device_target()
 


### PR DESCRIPTION
This fixes building the parameter string passed to xcodebuild. Prior to this patch, for at least Python 3.5 and 3.6, ios.py will throw this error:
```
Traceback (most recent call last):
  File "setup.py", line 79, in <module>
    'toga-django==0.3.0.dev8',
  File "/Users/curtis/dev/python/tutorial/venv/lib/python3.5/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/Users/curtis/.pyenv/versions/3.5.5/lib/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/Users/curtis/.pyenv/versions/3.5.5/lib/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/Users/curtis/.pyenv/versions/3.5.5/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/Users/curtis/dev/python/tutorial/venv/lib/python3.5/site-packages/briefcase/app.py", line 466, in run
    success = self.build_app()
  File "/Users/curtis/dev/python/tutorial/venv/lib/python3.5/site-packages/briefcase/ios.py", line 151, in build_app
    build_settings_str = ['{}={}'.format(x for x in build_settings)]
IndexError: tuple index out of range
```