### PR TITLE
Change "title" to kwarg for MainWindow in Tutorials

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -53,7 +53,7 @@ Check out what the provided ``helloworld/app.py`` file contains:
     class HelloWorld(toga.App):
         def startup(self):
             # Create a main window with a name matching the app
-            self.main_window = toga.MainWindow(self.name)
+            self.main_window = toga.MainWindow(title=self.name)
 
             # Create a main content box
             main_box = toga.Box()

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -25,7 +25,7 @@ Put the following code into ``helloworld\app.py``, replacing the old code:
 
       def startup(self):
           # Create a main window with a name matching the app
-          self.main_window = toga.MainWindow(self.name)
+          self.main_window = toga.MainWindow(title=self.name)
 
           # Create a main content box
           f_box = toga.Box()


### PR DESCRIPTION
In the feedback that @freakboy3742 gave me for pybee/toga#383, he pointed out that the title should be a keyword argument when creating the MainWindow of the App. This PR updates both briefcase tutorials to change them to keyword arguments.

Signed-off-by: Dan Yeaw <dan@yeaw.me>