### PR TITLE
Catch ValueError when choosing iOS version target

### DIFF
--- a/briefcase/ios.py
+++ b/briefcase/ios.py
@@ -86,8 +86,8 @@ class ios(app):
                         print('Available iOS versions:')
                         for i, label in enumerate(os_list):
                             print('  [{}] {}'.format(i+1, label))
-                        index = int(input('Which iOS version do you want to target: '))
                         try:
+                            index = int(input('Which iOS version do you want to target: '))
                             self.os_version = os_list[int(index) - 1]
                         except:
                             print("Invalid selection.")


### PR DESCRIPTION
When the user reaches the following point, if they enter (for example) `8.1`, rather than `1`, `python` throws a `ValueError`, because it's trying to convert to an `int`. This moves the version selection code inside the `"Invalid selection"` `try: except:` block, which gives the user another chance to enter the correct value, rather than crashing.

    Available iOS versions:
      [1] iOS 8.1
      [2] iOS 7.1
      [3] iOS 10.2
      [4] iOS 8.2
    Which iOS version do you want to target: 8.1