### PR TITLE
Optionally create MacOS dmg file

### DIFF
--- a/docs/background/quickstart.rst
+++ b/docs/background/quickstart.rst
@@ -22,7 +22,6 @@ specific settings can be specified using a platform key::
                     'toga-cocoa'
                 ],
                 'icon': 'icons/macos',
-                'dmg': True,
             },
             'ios': {
                 'app_requires': [

--- a/src/briefcase/app.py
+++ b/src/briefcase/app.py
@@ -82,8 +82,6 @@ class app(Command):
          "Set the device to run. (e.g., iPhone 7 Plus)"),
         ('sanitize-version', None,
          "Forces installer version to only contain numbers."),
-        ('dmg', None,
-         'Create DMG (for macOS)'),
         ('clean', None,
          "Delete any artifacts from previous run")
     ]
@@ -110,7 +108,6 @@ class app(Command):
         self.os_version = None
         self.device_name = None
         self.sanitize_version = None
-        self.dmg = None
         self.clean = None
 
     def finalize_options(self):

--- a/src/briefcase/macos.py
+++ b/src/briefcase/macos.py
@@ -26,8 +26,10 @@ class macos(app):
 
         if self.dir is None:
             self.dir = 'macOS'
+        
+        self.app_location = os.path.join(self.dir, '{}.app'.format(self.formal_name)) #Location of the .app file
 
-        self.resource_dir = os.path.join(self.dir, '{}.app'.format(self.formal_name), 'Contents', 'Resources')
+        self.resource_dir = os.path.join(self.app_location, 'Contents', 'Resources')
 
     def install_icon(self):
         shutil.copyfile(
@@ -61,9 +63,12 @@ class macos(app):
 
     def build_app(self):
         print("Building DMG file...")
-        dmg_name = self.formal_name.replace(' ', '_') + '.dmg'
+        dmg_name = self.formal_name + '.dmg'
         dmg_path = os.path.join(os.path.abspath(self.dir), dmg_name)
-        dmgbuild.build_dmg(filename=dmg_path, volume_name=self.formal_name)
+        settings = {'files': [self.app_location],
+                    'symlinks': {'Applications': '/Applications'}}
+        dmgbuild.build_dmg(filename=dmg_path,
+                           volume_name=self.formal_name, settings=settings)
 
         return True
 

--- a/src/briefcase/macos.py
+++ b/src/briefcase/macos.py
@@ -14,7 +14,7 @@ class macos(app):
     def finalize_options(self):
         # Copy over all the options from the base 'app' command
         finalized = self.get_finalized_command('app')
-        for attr in ('formal_name', 'organization_name', 'bundle', 'icon', 'download_dir', 'dmg'):
+        for attr in ('formal_name', 'organization_name', 'bundle', 'icon', 'download_dir', 'document_types'):
             if getattr(self, attr) is None:
                 setattr(self, attr, getattr(finalized, attr))
 
@@ -60,11 +60,10 @@ class macos(app):
         return macos_dir
 
     def build_app(self):
-        if self.dmg:
-            print("Building DMG file...")
-            dmg_name = self.formal_name.replace(' ', '_') + '.dmg'
-            dmg_path = os.path.join(os.path.abspath(self.dir), dmg_name)
-            dmgbuild.build_dmg(filename=dmg_path, volume_name=self.formal_name)
+        print("Building DMG file...")
+        dmg_name = self.formal_name.replace(' ', '_') + '.dmg'
+        dmg_path = os.path.join(os.path.abspath(self.dir), dmg_name)
+        dmgbuild.build_dmg(filename=dmg_path, volume_name=self.formal_name)
 
         return True
 


### PR DESCRIPTION
Continues the work from #132 and closes #130 
Points from the review
- [x] Make dmg the default macOS build option
- [x] Insert files into dmg 
- [x] insert a symlink to Applications
- [ ] provide an icon for the volume
- [ ] provide a custom background image (This will have to be a macOs specific argument right?)
- [ ] set the initial size of the mounted window ( I think the default is fine because these builds will only have two files - the `.app` and the symlink)