### PR TITLE
Added urllib3 version to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'requests < 3.0',
         'boto3 >= 1.4.4',
         # 10/18/18 - Pinning the urllib3 version to solve Boto dependency issues
-        'urllib3 = 1.22'
+        'urllib3 == 1.22'
     ],
     license='New BSD',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
         'setuptools >= 40.0',
         'requests < 3.0',
         'boto3 >= 1.4.4',
+        # 10/18/18 - Pinning the urllib3 version is a temporary fix to solve conflicting dependency issues with Boto3 & Requests
+        'urllib3 = 1.22' 
     ],
     license='New BSD',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ setup(
         'setuptools >= 40.0',
         'requests < 3.0',
         'boto3 >= 1.4.4',
-        # 10/18/18 - Pinning the urllib3 version is a temporary fix to solve conflicting dependency issues with Boto3 & Requests
-        'urllib3 = 1.22' 
+        # 10/18/18 - Pinning the urllib3 version to solve Boto dependency issues
+        'urllib3 = 1.22'
     ],
     license='New BSD',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'setuptools >= 40.0',
         'requests < 3.0',
         'boto3 >= 1.4.4',
-        # 10/18/18 - Pinning the urllib3 version to solve Boto dependency issues
+        # 2018-10: Pinning the urllib3 version to solve Boto dependency issues
         'urllib3 == 1.22'
     ],
     license='New BSD',


### PR DESCRIPTION
Assigned the package `urllib3`  to use version `1.22`. This should eliminate the VersionConflict errors being raised by `botocore` for the time being. 