### PR TITLE
add pycairo to pip install

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -24,7 +24,7 @@ Let's get started by using
 
 .. code-block:: bash
 
-    $ pip install cookiecutter briefcase
+    $ pip install pycairo cookiecutter briefcase
     $ cookiecutter https://github.com/pybee/briefcase-template
 
 This will ask a bunch of questions of you. We'll use an `app_name` of


### PR DESCRIPTION
I had the same issue as https://github.com/pybee/briefcase/issues/176
but for me
pip install pycairo
solved it.  Also I think this is a preferable solve in a virtual environment, instead of installing a linux package, which was the solve in the linked issue.