### PR TITLE
Remove redundant pip install briefcase

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -24,7 +24,7 @@ Let's get started by using
 
 .. code-block:: bash
 
-    $ pip install cookiecutter briefcase
+    $ pip install cookiecutter
     $ cookiecutter https://github.com/pybee/briefcase-template
 
 This will ask a bunch of questions of you. We'll use an `app_name` of


### PR DESCRIPTION
Briefcase instructions already included on getting-started page. No need  to pip it again.