### PR TITLE
Modify mechanism for starting iOS simulator.

### DIFF
--- a/src/briefcase/android.py
+++ b/src/briefcase/android.py
@@ -83,6 +83,10 @@ class android(app):
             else:
                 print("WARNING: No {} splash file available.".format(size))
 
+    def install_launch_scripts(self):
+        # Complete bypass launch scripts for Android
+        print(" * Skipping creation of launch scripts.")
+
     def post_install(self):
         print()
         print("Installation complete.")


### PR DESCRIPTION
At some point, the `instruments` call stopped working as a way to start the simulator. 

There's also a potential problem with using Popen.wait() if there's a lot of input; check_output() is a more reliable method.

Lastly, mobile platforms can't support launch scripts, so they need to be disabled.